### PR TITLE
ci: add Chromatic visual regression testing

### DIFF
--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -114,6 +114,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
 
       - name: Set Node version
         uses: actions/setup-node@v4.2.0
@@ -151,6 +153,15 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./packages/breeze-ui/storybook-static
+
+      # Pinned to major version for stability while receiving patch updates
+      - name: Run Chromatic
+        uses: chromaui/action@v11
+        with:
+          workingDir: packages/breeze-ui
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          storybookBuildDir: storybook-static
+          autoAcceptChanges: main
 
   # deploy-auth0-tenant:
   #   runs-on: ubuntu-latest

--- a/.github/workflows/quality-assurance.yml
+++ b/.github/workflows/quality-assurance.yml
@@ -1,6 +1,9 @@
 name: Quality assurance
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     types:
       - opened
@@ -12,6 +15,8 @@ jobs:
     name: Label PR
 
     runs-on: ubuntu-latest
+
+    if: github.event_name == 'pull_request'
 
     steps:
       - uses: actions/labeler@v5.0.0

--- a/.github/workflows/quality-assurance.yml
+++ b/.github/workflows/quality-assurance.yml
@@ -1,9 +1,6 @@
 name: Quality assurance
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     types:
       - opened
@@ -15,8 +12,6 @@ jobs:
     name: Label PR
 
     runs-on: ubuntu-latest
-
-    if: github.event_name == 'pull_request'
 
     steps:
       - uses: actions/labeler@v5.0.0
@@ -182,5 +177,4 @@ jobs:
           workingDir: packages/breeze-ui
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           buildScriptName: deploy
-          autoAcceptChanges: main
           exitOnceUploaded: true

--- a/.github/workflows/quality-assurance.yml
+++ b/.github/workflows/quality-assurance.yml
@@ -128,3 +128,53 @@ jobs:
         uses: SonarSource/sonarqube-scan-action@v6.0.0
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+  chromatic:
+    name: Chromatic
+
+    runs-on: ubuntu-latest
+
+    needs: setup
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Set Node version
+        uses: actions/setup-node@v4.2.0
+        with:
+          node-version-file: .nvmrc
+          cache: yarn
+
+      - name: Generate packages cache key
+        run: ./scripts/checksum.sh ./packages.txt packages
+
+      - name: Restore Node modules
+        uses: actions/cache@v4.2.2
+        with:
+          path: |
+            ./node_modules
+            ./applications/*/*/node_modules
+            ./packages/*/node_modules
+          key: ${{ runner.os }}-modules-v4-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-modules-
+
+      - name: Restore packages
+        uses: actions/cache@v4.2.2
+        with:
+          path: ./packages/*/lib
+          key: ${{ runner.os }}-packages-v4-${{ hashFiles('**/packages.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-packages-
+
+      - name: Run Chromatic
+        uses: chromaui/action@latest
+        with:
+          workingDir: packages/breeze-ui
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          buildScriptName: deploy
+          autoAcceptChanges: main
+          exitOnceUploaded: true

--- a/.github/workflows/quality-assurance.yml
+++ b/.github/workflows/quality-assurance.yml
@@ -170,8 +170,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-packages-
 
+      # Pinned to major version for stability while receiving patch updates
       - name: Run Chromatic
-        uses: chromaui/action@latest
+        uses: chromaui/action@v11
         with:
           workingDir: packages/breeze-ui
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}


### PR DESCRIPTION
Add Chromatic job to quality-assurance workflow for visual regression testing of breeze-ui components.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated visual test (Chromatic) to CI, running for PRs and main and integrated into deploy/storybook flow.
  * Improved Node dependency caching and restore across CI to speed runs.
  * Ensured visual test steps run in parallel with other jobs and added full-history checkout where needed for deployments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->