### PR TITLE
test(breeze-ui): tolerate today label in range calendar story

### DIFF
--- a/packages/breeze-ui/src/primitives/RangeCalendar/RangeCalendar.stories.tsx
+++ b/packages/breeze-ui/src/primitives/RangeCalendar/RangeCalendar.stories.tsx
@@ -90,7 +90,9 @@ export const UncontrolledRange: Story = {
       }),
     );
     await userEvent.click(
-      canvas.getByRole('button', { name: /^Wednesday,? 22 July 2026$/i }),
+      canvas.getByRole('button', {
+        name: /^(?:Today, )?Wednesday,? 22 July 2026$/i,
+      }),
     );
     await expect(args.onChange).toHaveBeenLastCalledWith({
       end: '2026-07-22',


### PR DESCRIPTION
## What changed

- Allow the `RangeCalendar` uncontrolled-range Storybook interaction to match React Aria's optional `Today, ` accessible-name prefix for 22 July 2026.

## Why

The interaction used an exact accessible-name match for `Wednesday, 22 July 2026`. When that date is today, React Aria exposes the button as `Today, Wednesday, 22 July 2026`, causing the pipeline test to fail even though the calendar behavior is correct.

This keeps the test deterministic across the date boundary without changing production behavior.

## Validation

- `yarn workspace @motech-development/breeze-ui vitest run --project storybook src/primitives/RangeCalendar/RangeCalendar.stories.tsx` — 4 tests passed
- ESLint passed for the changed story
- Prettier check passed
- Breeze UI TypeScript typecheck passed

Pipeline failure: https://github.com/motech-development/platform/actions/runs/29916667526/job/88912051424?pr=1502


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved calendar interaction test reliability when selecting dates labeled with or without a “Today” prefix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->