### PR TITLE
test(ci): validate dependency cache fallback routes

### DIFF
--- a/.github/actions/setup-dependencies/action.yml
+++ b/.github/actions/setup-dependencies/action.yml
@@ -34,7 +34,7 @@ runs:
           ./applications/*/*/node_modules
           ./packages/*/node_modules
           ./.yarn/install-state.gz
-        key: ${{ runner.os }}-${{ runner.arch }}-installed-dependencies-v1-node-${{ steps.runtime.outputs.version }}-${{ hashFiles('.nvmrc') }}-${{ hashFiles('yarn.lock', '.yarnrc.yml', '.yarn/releases/**', '.yarn/plugins/**', '.yarn/patches/**', 'package.json', 'applications/*/*/package.json', 'packages/*/package.json') }}
+        key: ${{ runner.os }}-${{ runner.arch }}-installed-dependencies-v1-issue-1501-archive-fallback-node-${{ steps.runtime.outputs.version }}-${{ hashFiles('.nvmrc') }}-${{ hashFiles('yarn.lock', '.yarnrc.yml', '.yarn/releases/**', '.yarn/plugins/**', '.yarn/patches/**', 'package.json', 'applications/*/*/package.json', 'packages/*/package.json') }}
 
     - name: Restore Yarn archives
       id: yarn-archives

--- a/.github/actions/setup-dependencies/action.yml
+++ b/.github/actions/setup-dependencies/action.yml
@@ -34,7 +34,7 @@ runs:
           ./applications/*/*/node_modules
           ./packages/*/node_modules
           ./.yarn/install-state.gz
-        key: ${{ runner.os }}-${{ runner.arch }}-installed-dependencies-v1-issue-1501-archive-fallback-node-${{ steps.runtime.outputs.version }}-${{ hashFiles('.nvmrc') }}-${{ hashFiles('yarn.lock', '.yarnrc.yml', '.yarn/releases/**', '.yarn/plugins/**', '.yarn/patches/**', 'package.json', 'applications/*/*/package.json', 'packages/*/package.json') }}
+        key: ${{ runner.os }}-${{ runner.arch }}-installed-dependencies-v1-issue-1501-cold-install-node-${{ steps.runtime.outputs.version }}-${{ hashFiles('.nvmrc') }}-${{ hashFiles('yarn.lock', '.yarnrc.yml', '.yarn/releases/**', '.yarn/plugins/**', '.yarn/patches/**', 'package.json', 'applications/*/*/package.json', 'packages/*/package.json') }}
 
     - name: Restore Yarn archives
       id: yarn-archives
@@ -44,9 +44,9 @@ runs:
         path: |
           ~/.yarn/berry/cache
           ./.yarn/cache
-        key: ${{ runner.os }}-${{ runner.arch }}-yarn-archives-v1-node-${{ steps.runtime.outputs.version }}-${{ hashFiles('.nvmrc') }}-${{ hashFiles('yarn.lock') }}
+        key: ${{ runner.os }}-${{ runner.arch }}-yarn-archives-v1-issue-1501-cold-install-node-${{ steps.runtime.outputs.version }}-${{ hashFiles('.nvmrc') }}-${{ hashFiles('yarn.lock') }}
         restore-keys: |
-          ${{ runner.os }}-${{ runner.arch }}-yarn-archives-v1-node-${{ steps.runtime.outputs.version }}-${{ hashFiles('.nvmrc') }}-
+          ${{ runner.os }}-${{ runner.arch }}-yarn-archives-v1-issue-1501-cold-install-node-${{ steps.runtime.outputs.version }}-${{ hashFiles('.nvmrc') }}-
 
     - name: Install dependencies
       if: steps.installed-dependencies.outputs.cache-hit != 'true'


### PR DESCRIPTION
## Summary

- force the reusable dependency setup action through an archive-fallback route
- follow with a second commit that forces a true cold-install route
- collect temporary GitHub Actions evidence for issue #1501

## Scope

This is an explicitly throwaway validation PR. Do not merge it. Changes are limited to cache namespaces in `.github/actions/setup-dependencies/action.yml`.

The `.github/actions`-only diff is classified by the Preview impact planner as non-runtime (`runtimeAffected: false`), so no Preview Deployment Unit or cloud deployment should run. The explicit Preview and Playwright not-applicable paths are expected.

## Validation

- targeted Preview impact fixture test
- direct `--preview-impact` result for `.github/actions/setup-dependencies/action.yml`
- generated workflow drift check
- `git diff --check`

The full delivery generator suite has one expected validation-experiment failure because it asserts that this reusable action and generated deployment jobs use identical cache keys. Updating generated delivery files would make this PR runtime-affecting and is intentionally out of scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dependency cache restoration behavior across different operating systems and processor architectures.
  * Updated dependency and Yarn archive cache keys to better account for changes in project configuration and related settings, improving fallback matching when exact cache entries miss.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->