### PR TITLE
fix(delivery): skip draft Preview aggregators

### DIFF
--- a/.github/delivery/generate.test.mjs
+++ b/.github/delivery/generate.test.mjs
@@ -1590,6 +1590,7 @@ test('generated preview workflow plans per pull request and selectively deploys 
     /concurrency:\n  group: preview-pr-\$\{\{ github\.event\.pull_request\.number \}\}\n  cancel-in-progress: false/,
   );
   assert.match(setup, /name: Preview plan/);
+  assert.match(setup, /^    if: github\.event\.pull_request\.draft == false$/m);
   assert.match(
     setup,
     /- name: Checkout code\n        uses: actions\/checkout@v7\n        with:\n          fetch-depth: 0\n          persist-credentials: false\n          ref: \$\{\{ github\.event\.pull_request\.head\.sha \}\}/,
@@ -1674,6 +1675,10 @@ test('generated preview workflow plans per pull request and selectively deploys 
   );
   assert.match(
     previewStatus,
+    /^    if: always\(\) && github\.event\.pull_request\.draft == false$/m,
+  );
+  assert.match(
+    previewStatus,
     /name: Report planning failure\n        if: needs\.setup\.result != 'success'/,
   );
   assert.match(
@@ -1702,6 +1707,10 @@ test('generated preview workflow plans per pull request and selectively deploys 
     /needs\.accounts-api\.outputs\.appsync-url \|\| needs\.setup\.outputs\.api-appsync-url[\s\S]*needs\.accounts-api\.outputs\.aws-region \|\| needs\.setup\.outputs\.api-aws-region/,
   );
   assert.match(playwrightStatus, /Playwright is not applicable/);
+  assert.match(
+    playwrightStatus,
+    /^    if: always\(\) && github\.event\.pull_request\.draft == false$/m,
+  );
   assert.match(playwrightStatus, /^      deployments: write$/m);
   assert.match(
     playwrightStatus,

--- a/.github/delivery/templates/deploy-to-environment.yml
+++ b/.github/delivery/templates/deploy-to-environment.yml
@@ -662,7 +662,7 @@ jobs:
       - accounts-reports
       - accounts-api
 
-    if: always()
+    if: always() && github.event.pull_request.draft == false
 
     steps:
       - name: Report planning failure
@@ -758,7 +758,7 @@ jobs:
       - setup
       - accounts-client
 
-    if: always()
+    if: always() && github.event.pull_request.draft == false
 
     permissions:
       contents: read

--- a/.github/workflows/deploy-to-environment.yml
+++ b/.github/workflows/deploy-to-environment.yml
@@ -1933,7 +1933,7 @@ jobs:
       - accounts-reports
       - accounts-api
 
-    if: always()
+    if: always() && github.event.pull_request.draft == false
 
     steps:
       - name: Report planning failure
@@ -2109,7 +2109,7 @@ jobs:
       - setup
       - accounts-client
 
-    if: always()
+    if: always() && github.event.pull_request.draft == false
 
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

- retain the existing draft guard on Preview planning
- skip the Preview and Playwright aggregation jobs while a pull request is draft
- add focused regression assertions for all three draft guards and regenerate the Preview workflow

## Root cause

On a draft pull request `opened`, `reopened`, or `synchronize` event, the `setup` job is intentionally skipped. The two aggregation jobs still ran under `if: always()`, so Preview treated the skipped setup as a planning failure and Playwright published a failing commit status.

This was observed on #1504 in Actions runs [30037333299](https://github.com/motech-development/platform/actions/runs/30037333299) and [30039487661](https://github.com/motech-development/platform/actions/runs/30039487661).

The new guards apply only to draft pull requests. Non-draft setup failures and skips still fail closed; the existing planning-failure and no-generic-skipped-as-success assertions remain in place.

## Impact

The initial draft event skipped every Preview job, published no Playwright commit status, created no GitHub Deployments, and performed no cloud mutation. After explicit approval to mark this runtime-affecting change ready for review, the full Preview topology deployed successfully and both Playwright shards passed.

## Validation

- `node --test .github/delivery/*.test.mjs`
- `node .github/delivery/generate.mjs --check`
- `yarn prettier --check .github/delivery/generate.test.mjs .github/delivery/templates/deploy-to-environment.yml .github/workflows/deploy-to-environment.yml`
- `git diff --check`
- draft Preview run [30041190874](https://github.com/motech-development/platform/actions/runs/30041190874): all Preview jobs skipped, no Playwright status, no Deployment records
- ready-for-review Preview run [30043392780](https://github.com/motech-development/platform/actions/runs/30043392780): all Deployment Units, Preview aggregation, both Playwright shards, and Playwright status passed

Refs #1501
