### PR TITLE
test(delivery): validate selective preview repair

### DIFF
--- a/applications/accounts/reports/src/handlers/__tests__/add-report.test.ts
+++ b/applications/accounts/reports/src/handlers/__tests__/add-report.test.ts
@@ -8,6 +8,7 @@ import { handler, IEvent } from '../add-report';
 
 describe('add-report', () => {
   // Validation marker: seed the complete Preview topology for issue #1501.
+  // Validation marker: trigger selective missing-stack repair for issue #1501.
   let callback: jest.Mock;
   let context: Context;
   let ddb: AwsClientStub<DynamoDBClient>;

--- a/applications/accounts/reports/src/handlers/__tests__/add-report.test.ts
+++ b/applications/accounts/reports/src/handlers/__tests__/add-report.test.ts
@@ -7,6 +7,7 @@ import { advanceTo, clear } from 'jest-date-mock';
 import { handler, IEvent } from '../add-report';
 
 describe('add-report', () => {
+  // Validation marker: seed the complete Preview topology for issue #1501.
   let callback: jest.Mock;
   let context: Context;
   let ddb: AwsClientStub<DynamoDBClient>;


### PR DESCRIPTION
## Validation only

**DO NOT MERGE.** This is a disposable validation-only pull request for the remaining Preview Environment criterion in #1501. It must stay open and unmerged until the validation evidence has been captured, then follow the normal teardown path if explicitly closed.

- The first commit seeds a complete Preview Environment from a harmless comment-only change in the `@accounts/reports` workspace.
- After that complete Preview and both unchanged Playwright shards succeed, a later commit will validate selective dependant-aware delivery and missing-stack repair.
- No Develop or production resources are in scope.

## Local validation

- `yarn workspace @accounts/reports jest src/handlers/__tests__/add-report.test.ts --runInBand`
- `node --test .github/delivery/generate.test.mjs`
- `node .github/delivery/generate.mjs --check`
- `yarn workspace @accounts/reports exec prettier --check src/handlers/__tests__/add-report.test.ts`
- `git diff --check`

Refs #1501


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added internal “validation marker” comments to the report creation test suite.
  * No user-facing behavior or test logic/operations were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->