### PR TITLE
fix(accounts): preserve scheduler mapping identity

### DIFF
--- a/applications/accounts/data/serverless.yml
+++ b/applications/accounts/data/serverless.yml
@@ -157,7 +157,7 @@ resources:
         MessageRetentionPeriod: 1209600
         QueueName: ${self:custom.prefix}-schedule-synchronisation-dlq
 
-    ScheduleTransactionsEventSourceMapping:
+    ScheduleTransactionsEventSourceMappingDynamodbApplicationTable:
       Type: AWS::Lambda::EventSourceMapping
       Properties:
         BatchSize: 1


### PR DESCRIPTION
## Summary

- preserve the CloudFormation logical ID of the existing ScheduleTransactions DynamoDB stream mapping
- update the mapping in place with the new retry and S3 failure destination settings
- prevent the duplicate mapping 409 that failed both long-lived environment deployments

## Root cause

Fresh Preview Environments did not contain the legacy mapping, but Develop and Production already managed the same stream/function pair as ScheduleTransactionsEventSourceMappingDynamodbApplicationTable. Renaming the resource caused CloudFormation to create the replacement before deleting the existing mapping, which Lambda rejected as AlreadyExists.

## Validation

- packaged accounts-data with Serverless for the local stage
- confirmed the generated template contains one ScheduleTransactions event source mapping under the legacy logical ID
- confirmed BatchSize, MaximumRetryAttempts, and the S3 OnFailure destination remain configured
- git diff --check

Failed release: https://github.com/motech-development/platform/actions/runs/30103241286

Follow-up to #1511.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the internal identifier for the Schedule Transactions event source mapping while preserving its existing configuration and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->