### PR TITLE
feat(breeze-ui): add shell lifecycle contracts

### DIFF
--- a/packages/breeze-ui/src/patterns/ApplicationShell/ApplicationShell.mdx
+++ b/packages/breeze-ui/src/patterns/ApplicationShell/ApplicationShell.mdx
@@ -78,6 +78,29 @@ The root contains a visible-on-focus skip link, a persistent rail from the `md` 
 
 The drawer uses logical `start`, so it opens from the left in left-to-right layouts and the right in right-to-left layouts. The shell supplies layout and landmarks; the application supplies destinations, the current route, translated product copy, context selection, account actions, loading/error content, and data fetching.
 
+## Compact-navigation lifecycle
+
+Compact navigation is uncontrolled by default. Use `defaultCompactNavigationOpen` to choose its initial state and `onCompactNavigationOpenChange` to observe trigger, close, Escape, and outside-dismissal changes.
+
+Use `compactNavigationOpen` with `onCompactNavigationOpenChange` when persistent application route state must close the drawer after successful navigation:
+
+```tsx
+const [compactNavigationOpen, setCompactNavigationOpen] = useState(false);
+const route = useCurrentRoute();
+
+useEffect(() => {
+  setCompactNavigationOpen(false);
+}, [route]);
+
+<ApplicationShell
+  compactNavigationOpen={compactNavigationOpen}
+  onCompactNavigationOpenChange={setCompactNavigationOpen}
+  // ...
+/>;
+```
+
+Keep destinations as links and close from an observed route change. Do not replace links with buttons or close from every click, because modified clicks, alternate targets, downloads, and external URLs must retain native browser behaviour. Compact open state does not hide or alter the wide navigation rail.
+
 ## Accessibility, keyboard, and routing
 
 - `skipLinkLabel` must clearly describe bypassing repeated navigation. Its target is `mainId`, which defaults to `main-content`; keep that id unique on the page.
@@ -99,6 +122,7 @@ The drawer uses logical `start`, so it opens from the left in left-to-right layo
 - Do not use physical left/right assumptions; direction is provider-controlled.
 - Do not hard-code the shell breakpoint or rail offset in application CSS.
 - Do not assume the frame performs route changes, signs users out, fetches contexts, or announces page loading.
+- Do not combine `compactNavigationOpen` with `defaultCompactNavigationOpen`, or provide controlled state without `onCompactNavigationOpenChange`.
 
 ## Related components
 

--- a/packages/breeze-ui/src/patterns/ApplicationShell/ApplicationShell.stories.tsx
+++ b/packages/breeze-ui/src/patterns/ApplicationShell/ApplicationShell.stories.tsx
@@ -1,14 +1,19 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { expect, userEvent, within } from 'storybook/test';
+import { useState } from 'react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
 import { ArrowRightIcon, InfoIcon, SignOutIcon } from '../../icons';
 import { Avatar } from '../../primitives/Avatar/Avatar';
 import { Inline } from '../../primitives/Inline/Inline';
 import { Logo } from '../../primitives/Logo/Logo';
 import { NavigationList } from '../../primitives/NavigationList/NavigationList';
 import { Typography } from '../../primitives/Typography/Typography';
+import { BreezeProvider } from '../../provider/BreezeProvider';
 import { ContextSwitcher } from '../ContextSwitcher/ContextSwitcher';
 import { UserMenu } from '../UserMenu/UserMenu';
-import { ApplicationShell } from './ApplicationShell';
+import {
+  ApplicationShell,
+  type ApplicationShellProps,
+} from './ApplicationShell';
 
 const navigation = (
   <NavigationList.Root aria-label="Primary navigation">
@@ -84,7 +89,7 @@ const meta = {
     layout: 'fullscreen',
   },
   title: 'Patterns/Application Shell/ApplicationShell',
-} satisfies Meta<typeof ApplicationShell>;
+} satisfies Meta<ApplicationShellProps>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
@@ -131,6 +136,57 @@ export const CompactNavigation: Story = {
       window.innerWidth,
     );
   },
+};
+
+function ControlledCompactNavigationFrame() {
+  const [compactNavigationOpen, setCompactNavigationOpen] = useState(false);
+
+  return (
+    <BreezeProvider
+      locale="en-GB"
+      router={{ navigate: () => setCompactNavigationOpen(false) }}
+    >
+      <ApplicationShell
+        account={userMenu}
+        brand={brand}
+        compactBrand={compactBrand}
+        compactNavigationOpen={compactNavigationOpen}
+        context={context}
+        navigation={navigation}
+        navigationLabel="Open navigation"
+        onCompactNavigationOpenChange={setCompactNavigationOpen}
+        skipLinkLabel="Skip to content"
+      >
+        <Typography as="h1">Overview</Typography>
+      </ApplicationShell>
+    </BreezeProvider>
+  );
+}
+
+/**
+ * Lets application route state control compact navigation while destinations
+ * remain native anchors and the wide rail retains the same navigation.
+ *
+ * @summary controlled compact navigation closed after route activation
+ */
+export const ControlledCompactNavigation: Story = {
+  ...CompactNavigation,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(
+      canvas.getByRole('button', { name: 'Open navigation' }),
+    );
+    const dialog = within(document.body).getByRole('dialog');
+    const destination = within(dialog).getByRole('link', { name: 'Projects' });
+
+    await expect(destination).toHaveAttribute('href', '/projects');
+    await userEvent.click(destination);
+    await waitFor(() =>
+      expect(within(document.body).queryByRole('dialog')).toBeNull(),
+    );
+  },
+  render: ControlledCompactNavigationFrame,
 };
 
 /**

--- a/packages/breeze-ui/src/patterns/ApplicationShell/ApplicationShell.test.tsx
+++ b/packages/breeze-ui/src/patterns/ApplicationShell/ApplicationShell.test.tsx
@@ -1,12 +1,16 @@
-import { screen } from '@testing-library/react';
+import { screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, expect, it } from 'vitest';
+import { useState } from 'react';
+import { describe, expect, it, vi } from 'vitest';
 import renderBreeze from '../../../test/render';
+import { Link } from '../../primitives/Link/Link';
+import { BreezeProvider } from '../../provider/BreezeProvider';
 import { ApplicationShell } from './ApplicationShell';
 
 describe('ApplicationShell', () => {
   it('provides skip navigation, shell slots, and an accessible compact drawer', async () => {
     const user = userEvent.setup();
+    const onCompactNavigationOpenChange = vi.fn();
 
     renderBreeze(
       <ApplicationShell
@@ -16,6 +20,7 @@ describe('ApplicationShell', () => {
         context={<span>Context</span>}
         navigation={<a href="/overview">Overview</a>}
         navigationLabel="Open navigation"
+        onCompactNavigationOpenChange={onCompactNavigationOpenChange}
         skipLinkLabel="Skip to content"
       >
         <h1>Overview</h1>
@@ -29,6 +34,7 @@ describe('ApplicationShell', () => {
     expect(screen.getByRole('main')).toHaveClass('py-6', 'sm:py-12');
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     await user.click(screen.getByRole('button', { name: 'Open navigation' }));
+    expect(onCompactNavigationOpenChange).toHaveBeenLastCalledWith(true);
     const dialog = screen.getByRole('dialog');
 
     expect(dialog).toBeVisible();
@@ -37,6 +43,75 @@ describe('ApplicationShell', () => {
     expect(dialog.closest('.breeze-drawer-motion')).not.toBeNull();
     expect(screen.getByText('Compact product')).toBeVisible();
     await user.click(screen.getByRole('button', { name: 'Close' }));
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(onCompactNavigationOpenChange).toHaveBeenLastCalledWith(false);
+    expect(onCompactNavigationOpenChange).toHaveBeenCalledTimes(2);
+  });
+
+  it('lets a controlled consumer close compact navigation after ordinary link navigation', async () => {
+    const user = userEvent.setup();
+    const navigate = vi.fn();
+
+    function ControlledShell() {
+      const [compactNavigationOpen, setCompactNavigationOpen] = useState(true);
+
+      return (
+        <BreezeProvider
+          locale="en-GB"
+          router={{
+            navigate: (href) => {
+              navigate(href);
+              setCompactNavigationOpen(false);
+            },
+          }}
+        >
+          <ApplicationShell
+            account={<span>Account</span>}
+            brand={<strong>Product</strong>}
+            compactNavigationOpen={compactNavigationOpen}
+            navigation={
+              <nav aria-label="Primary navigation">
+                <Link href="/projects">Projects</Link>
+                <Link href="/projects" target="_blank">
+                  Open projects in a new tab
+                </Link>
+              </nav>
+            }
+            navigationLabel="Open navigation"
+            onCompactNavigationOpenChange={setCompactNavigationOpen}
+            skipLinkLabel="Skip to content"
+          >
+            <h1>Overview</h1>
+          </ApplicationShell>
+        </BreezeProvider>
+      );
+    }
+
+    renderBreeze(<ControlledShell />);
+
+    const dialog = screen.getByRole('dialog');
+    const destination = within(dialog).getByRole('link', { name: 'Projects' });
+    const newTabDestination = within(dialog).getByRole('link', {
+      name: 'Open projects in a new tab',
+    });
+
+    expect(destination).toHaveAttribute('href', '/projects');
+    destination.addEventListener('click', (event) => {
+      if (event.ctrlKey) {
+        event.preventDefault();
+      }
+    });
+    await user.keyboard('{Control>}');
+    await user.click(destination);
+    await user.keyboard('{/Control}');
+    expect(navigate).not.toHaveBeenCalled();
+    expect(screen.getByRole('dialog')).toBeVisible();
+    expect(newTabDestination).toHaveAttribute('target', '_blank');
+    await user.click(newTabDestination);
+    expect(navigate).not.toHaveBeenCalled();
+    expect(screen.getByRole('dialog')).toBeVisible();
+    await user.click(destination);
+    expect(navigate).toHaveBeenCalledExactlyOnceWith('/projects');
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
   });
 });

--- a/packages/breeze-ui/src/patterns/ApplicationShell/ApplicationShell.tsx
+++ b/packages/breeze-ui/src/patterns/ApplicationShell/ApplicationShell.tsx
@@ -6,8 +6,7 @@ import { Drawer } from '../../primitives/Drawer/Drawer';
 import { SkipLink } from '../../primitives/SkipLink/SkipLink';
 import { useBreezeContext } from '../../provider/BreezeContext';
 
-/** Props for the shared responsive application frame. */
-export interface ApplicationShellProps
+interface ApplicationShellSharedProps
   extends Omit<HTMLAttributes<HTMLDivElement>, 'children' | 'style' | 'title'> {
   /** Account or user-menu slot in the shell footer and compact header. */
   account: ReactNode;
@@ -31,6 +30,26 @@ export interface ApplicationShellProps
   mainId?: string;
 }
 
+interface ControlledApplicationShellProps {
+  /** Current compact-navigation drawer state. */
+  compactNavigationOpen: boolean;
+  defaultCompactNavigationOpen?: never;
+  /** Called with the next compact-navigation drawer state. */
+  onCompactNavigationOpenChange: (open: boolean) => void;
+}
+
+interface UncontrolledApplicationShellProps {
+  compactNavigationOpen?: never;
+  /** Initial compact-navigation drawer state. Defaults to `false`. */
+  defaultCompactNavigationOpen?: boolean;
+  /** Called with the next compact-navigation drawer state. */
+  onCompactNavigationOpenChange?: (open: boolean) => void;
+}
+
+/** Props for the shared responsive application frame. */
+export type ApplicationShellProps = ApplicationShellSharedProps &
+  (ControlledApplicationShellProps | UncontrolledApplicationShellProps);
+
 /**
  * Frames brand, navigation, context, account controls, and main content
  * responsively.
@@ -43,15 +62,74 @@ export function ApplicationShell({
   children,
   className,
   compactBrand,
+  compactNavigationOpen,
   context,
+  defaultCompactNavigationOpen,
   mainId = 'main-content',
   navigation,
   navigationLabel,
+  onCompactNavigationOpenChange,
   ref,
   skipLinkLabel,
   ...props
 }: Readonly<ApplicationShellProps>): ReactElement {
   const { messages } = useBreezeContext();
+  const compactNavigationContent = (
+    <>
+      <Drawer.Trigger
+        aria-label={navigationLabel}
+        appearance="ghost"
+        className="size-11 border-0 p-0 text-[var(--breeze-ink-inverse)] data-[hovered]:bg-[var(--breeze-shell-soft)]"
+        variant="light"
+      >
+        <MenuIcon size="1.5rem" />
+      </Drawer.Trigger>
+      <Drawer.Content
+        className="max-h-none w-64 border-0 bg-[var(--breeze-shell)] p-0 text-[var(--breeze-ink-inverse)]"
+        chrome="none"
+        placement="start"
+      >
+        <div className="flex min-h-16 items-center justify-between border-b border-[var(--breeze-shell-soft)] px-4">
+          <div>{brand}</div>
+          <Drawer.Title className="sr-only">{navigationLabel}</Drawer.Title>
+          <Drawer.Close
+            aria-label={messages.close}
+            appearance="ghost"
+            className="size-11 border-0 p-0 text-[var(--breeze-ink-inverse)] data-[hovered]:bg-[var(--breeze-shell-soft)]"
+            variant="light"
+          >
+            <CloseIcon size="1.5rem" />
+          </Drawer.Close>
+        </div>
+        <Drawer.Description className="sr-only">
+          {navigationLabel}
+        </Drawer.Description>
+        <div className="min-h-0 flex-1 overflow-y-auto px-3 py-6 [&_a]:flex [&_a]:min-h-11 [&_a]:items-center [&_a]:gap-3 [&_a]:text-[var(--breeze-ink-inverse-muted)] [&_a]:no-underline [&_a[data-current]]:bg-[var(--breeze-primary-selected)] [&_a[data-current]]:text-white [&_a[data-current][data-hovered]]:bg-[var(--breeze-primary-selected)] [&_a[data-hovered]]:bg-[var(--breeze-shell-soft)] [&_a[data-hovered]]:text-white">
+          {navigation}
+        </div>
+        <footer className="grid gap-2 border-t border-[var(--breeze-shell-soft)] p-3">
+          {context}
+          {account}
+        </footer>
+      </Drawer.Content>
+    </>
+  );
+  const compactNavigation =
+    compactNavigationOpen === undefined ? (
+      <Drawer.Root
+        defaultOpen={defaultCompactNavigationOpen}
+        onOpenChange={onCompactNavigationOpenChange}
+      >
+        {compactNavigationContent}
+      </Drawer.Root>
+    ) : (
+      <Drawer.Root
+        onOpenChange={onCompactNavigationOpenChange}
+        open={compactNavigationOpen}
+      >
+        {compactNavigationContent}
+      </Drawer.Root>
+    );
 
   return createElement(
     'div',
@@ -75,44 +153,7 @@ export function ApplicationShell({
         </footer>
       </aside>
       <header className="grid min-h-16 grid-cols-[2.75rem_minmax(0,1fr)_2.75rem] items-center gap-3 bg-[var(--breeze-shell)] px-3 text-[var(--breeze-ink-inverse)] md:hidden">
-        <Drawer.Root>
-          <Drawer.Trigger
-            aria-label={navigationLabel}
-            appearance="ghost"
-            className="size-11 border-0 p-0 text-[var(--breeze-ink-inverse)] data-[hovered]:bg-[var(--breeze-shell-soft)]"
-            variant="light"
-          >
-            <MenuIcon size="1.5rem" />
-          </Drawer.Trigger>
-          <Drawer.Content
-            className="max-h-none w-64 border-0 bg-[var(--breeze-shell)] p-0 text-[var(--breeze-ink-inverse)]"
-            chrome="none"
-            placement="start"
-          >
-            <div className="flex min-h-16 items-center justify-between border-b border-[var(--breeze-shell-soft)] px-4">
-              <div>{brand}</div>
-              <Drawer.Title className="sr-only">{navigationLabel}</Drawer.Title>
-              <Drawer.Close
-                aria-label={messages.close}
-                appearance="ghost"
-                className="size-11 border-0 p-0 text-[var(--breeze-ink-inverse)] data-[hovered]:bg-[var(--breeze-shell-soft)]"
-                variant="light"
-              >
-                <CloseIcon size="1.5rem" />
-              </Drawer.Close>
-            </div>
-            <Drawer.Description className="sr-only">
-              {navigationLabel}
-            </Drawer.Description>
-            <div className="min-h-0 flex-1 overflow-y-auto px-3 py-6 [&_a]:flex [&_a]:min-h-11 [&_a]:items-center [&_a]:gap-3 [&_a]:text-[var(--breeze-ink-inverse-muted)] [&_a]:no-underline [&_a[data-current]]:bg-[var(--breeze-primary-selected)] [&_a[data-current]]:text-white [&_a[data-current][data-hovered]]:bg-[var(--breeze-primary-selected)] [&_a[data-hovered]]:bg-[var(--breeze-shell-soft)] [&_a[data-hovered]]:text-white">
-              {navigation}
-            </div>
-            <footer className="grid gap-2 border-t border-[var(--breeze-shell-soft)] p-3">
-              {context}
-              {account}
-            </footer>
-          </Drawer.Content>
-        </Drawer.Root>
+        {compactNavigation}
         <div className="min-w-0 justify-self-center font-[family-name:var(--breeze-font-display)] text-xl font-semibold">
           {compactBrand ?? brand}
         </div>

--- a/packages/breeze-ui/src/patterns/UserMenu/UserMenu.mdx
+++ b/packages/breeze-ui/src/patterns/UserMenu/UserMenu.mdx
@@ -49,6 +49,7 @@ import { SignOutIcon } from '@motech-development/breeze-ui/icons';
   notificationHeading="Notifications"
   notificationState="1 new"
   notifications="Your export is ready."
+  unreadLabel="User menu (1 unread)"
   userName="Taylor Reed"
 />;
 ```
@@ -61,7 +62,11 @@ import { SignOutIcon } from '@motech-development/breeze-ui/icons';
 
 `disabled` prevents an action from receiving focus or activation. `variant="danger"` provides danger emphasis; `default` is the default. Use danger only for genuinely destructive or terminating actions and provide confirmation separately when needed.
 
-`hasUnread` defaults to `false`. When true, the trigger gets a visible decorative dot and its accessible name appends the provider's `unreadNotifications` message. The pattern does not mark notifications read. Notification content is rendered only when `notifications` is supplied; the heading and state are optional supporting content.
+`hasUnread` defaults to `false`. When true, the trigger gets a visible decorative dot. By default its accessible name appends the provider's generic `unreadNotifications` message. Supply `unreadLabel` as the complete trigger name when the application knows a localized count, for example `Notifications (3 unread)`; it replaces the generic unread name rather than appending to it. When `hasUnread` is false, `aria-label` remains the complete trigger name, so an application may update it to `Notifications (0 unread)`.
+
+Open state is uncontrolled by default. Use `defaultOpen` for an initially open menu and `onOpenChange` to observe state without owning it. Use `open` with `onOpenChange` for controlled state. The callback receives one complete `false` state for Escape, outside dismissal, trigger toggle, or action activation. The application can use that close report to mark exactly the displayed notification ids read; `UserMenu` does not own or mutate notification state.
+
+Notification content is rendered only when `notifications` is supplied; the heading and state are optional supporting content.
 
 ## Accessibility, keyboard, and internationalisation
 
@@ -69,9 +74,9 @@ import { SignOutIcon } from '@motech-development/breeze-ui/icons';
 
 The trigger opens with pointer activation, `Enter`, `Space`, or the platform menu shortcut. Arrow keys move between enabled actions, typing searches labels, `Enter` or `Space` activates, `Home` and `End` move to boundaries, and `Escape` closes and restores focus. Logical alignment and `top start` placement follow provider direction.
 
-Translate the accessible label, notification copy, user-facing state, and action labels. `Unread notifications` comes from `BreezeProvider.messages.unreadNotifications`. Keep labels concise enough for narrow shell presentation.
+Translate the accessible label, `unreadLabel`, notification copy, user-facing state, and action labels. The generic `Unread notifications` fallback comes from `BreezeProvider.messages.unreadNotifications`. Keep labels concise enough for narrow shell presentation.
 
-There is no root loading, invalid, empty, disabled, controlled-open, or error state. Avoid opening an empty menu; render account-loading feedback outside it, disable individual actions during in-flight work, and show any failure in an application-owned alert or page region.
+There is no root loading, invalid, empty, disabled, read-only-open, or error state. Avoid opening an empty menu; render account-loading feedback outside it, disable individual actions during in-flight work, and show any failure in an application-owned alert or page region.
 
 ## API
 
@@ -79,4 +84,4 @@ There is no root loading, invalid, empty, disabled, controlled-open, or error st
 
 ## Common mistakes and related components
 
-Do not pass domain objects as ids, use a danger style for ordinary navigation, treat `hasUnread` as application state storage, or place a long notification feed in the popover. Related components: [ApplicationShell](?path=/docs/patterns-application-shell-applicationshell--docs), [Avatar](?path=/docs/foundation-avatar--docs), [Menu](?path=/docs/navigation-menu--docs), and [ConfirmationDialog](?path=/docs/patterns-actions-confirmationdialog--docs).
+Do not pass domain objects as ids, combine `open` with `defaultOpen`, use a danger style for ordinary navigation, treat `hasUnread` as application state storage, or place a long notification feed in the popover. Related components: [ApplicationShell](?path=/docs/patterns-application-shell-applicationshell--docs), [Avatar](?path=/docs/foundation-avatar--docs), [Menu](?path=/docs/navigation-menu--docs), and [ConfirmationDialog](?path=/docs/patterns-actions-confirmationdialog--docs).

--- a/packages/breeze-ui/src/patterns/UserMenu/UserMenu.stories.tsx
+++ b/packages/breeze-ui/src/patterns/UserMenu/UserMenu.stories.tsx
@@ -1,11 +1,14 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
 import { expect, fn, userEvent, within } from 'storybook/test';
 import StoryConstraint from '../../../.storybook/StoryConstraint';
 import { SignOutIcon } from '../../icons';
 import { Stack } from '../../primitives/Stack/Stack';
 import { Surface } from '../../primitives/Surface/Surface';
 import { Typography } from '../../primitives/Typography/Typography';
-import { UserMenu } from './UserMenu';
+import { UserMenu, type UserMenuProps } from './UserMenu';
+
+type UserMenuStoryProps = Extract<UserMenuProps, { open?: never }>;
 
 /**
  * Presents represented-user identity, optional notification content, and
@@ -25,7 +28,7 @@ const meta = {
     ),
   ],
   title: 'Patterns/Application Shell/UserMenu',
-} satisfies Meta<typeof UserMenu>;
+} satisfies Meta<UserMenuStoryProps>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
@@ -82,4 +85,54 @@ export const NotificationsAndActions: Story = {
     await userEvent.unhover(signOut);
     await expect(signOut).not.toHaveAttribute('data-hovered');
   },
+};
+
+function ControlledNotificationsMenu() {
+  const [open, setOpen] = useState(false);
+  const [unreadCount, setUnreadCount] = useState(3);
+  const hasUnread = unreadCount > 0;
+
+  return (
+    <UserMenu
+      aria-label={`Notifications (${unreadCount} unread)`}
+      actions={NotificationsAndActions.args.actions}
+      hasUnread={hasUnread}
+      notificationHeading="Notifications"
+      notificationState={`${unreadCount} unread`}
+      notifications="Your background task is complete."
+      onOpenChange={(nextOpen) => {
+        setOpen(nextOpen);
+
+        if (!nextOpen) {
+          setUnreadCount(0);
+        }
+      }}
+      open={open}
+      unreadLabel={`Notifications (${unreadCount} unread)`}
+      userName="Taylor Reed"
+    />
+  );
+}
+
+/**
+ * Reports dismissal to application state, which marks the displayed unread
+ * content read and updates the complete localized trigger name.
+ *
+ * @summary controlled dismissal with count-aware unread state
+ */
+export const ControlledDismissal: Story = {
+  ...NotificationsAndActions,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('button', {
+      name: 'Notifications (3 unread)',
+    });
+
+    await userEvent.click(trigger);
+    await userEvent.keyboard('{Escape}');
+    await expect(
+      canvas.getByRole('button', { name: 'Notifications (0 unread)' }),
+    ).toHaveFocus();
+  },
+  render: ControlledNotificationsMenu,
 };

--- a/packages/breeze-ui/src/patterns/UserMenu/UserMenu.test.tsx
+++ b/packages/breeze-ui/src/patterns/UserMenu/UserMenu.test.tsx
@@ -1,5 +1,6 @@
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import renderBreeze from '../../../test/render';
 import { SignOutIcon } from '../../icons';
@@ -54,5 +55,113 @@ describe('UserMenu', () => {
     );
 
     expect(screen.getByRole('button', { name: 'Account menu' })).toBeVisible();
+  });
+
+  it('uses a complete localized unread label without appending fallback copy', () => {
+    renderBreeze(
+      <UserMenu
+        aria-label="Notifications"
+        actions={[]}
+        hasUnread
+        unreadLabel="Notifications (3 unread)"
+        userName="Morgan Green"
+      />,
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'Notifications (3 unread)' }),
+    ).toBeVisible();
+  });
+
+  it('reports each menu dismissal path exactly once', async () => {
+    const user = userEvent.setup();
+    const onOutsideAction = vi.fn();
+    const onOpenChange = vi.fn();
+
+    renderBreeze(
+      <>
+        <button onClick={onOutsideAction} type="button">
+          Outside action
+        </button>
+        <UserMenu
+          aria-label="Account menu"
+          actions={[{ id: 'sign-out', label: 'Sign out' }]}
+          onOpenChange={onOpenChange}
+          userName="Morgan Green"
+        />
+      </>,
+    );
+    const outsideAction = screen.getByRole('button', {
+      name: 'Outside action',
+    });
+    const trigger = screen.getByRole('button', { name: 'Account menu' });
+    const openMenu = async () => {
+      await user.click(trigger);
+      expect(screen.getByRole('menu')).toBeVisible();
+      onOpenChange.mockClear();
+    };
+
+    await openMenu();
+    await user.keyboard('{Escape}');
+    expect(onOpenChange).toHaveBeenCalledExactlyOnceWith(false);
+    await waitFor(() => expect(trigger).toHaveFocus());
+
+    await openMenu();
+    await user.click(outsideAction);
+    expect(onOpenChange).toHaveBeenCalledExactlyOnceWith(false);
+    expect(onOutsideAction).toHaveBeenCalledOnce();
+
+    await openMenu();
+    await user.click(trigger);
+    expect(onOpenChange).toHaveBeenCalledExactlyOnceWith(false);
+
+    await openMenu();
+    await user.click(screen.getByRole('menuitem', { name: 'Sign out' }));
+    expect(onOpenChange).toHaveBeenCalledExactlyOnceWith(false);
+  });
+
+  it('lets a controlled consumer update count-aware state when the menu closes', async () => {
+    const user = userEvent.setup();
+
+    function ControlledNotifications() {
+      const [open, setOpen] = useState(true);
+      const [unreadCount, setUnreadCount] = useState(3);
+      const hasUnread = unreadCount > 0;
+
+      return (
+        <UserMenu
+          aria-label={`Notifications (${unreadCount} unread)`}
+          actions={[]}
+          hasUnread={hasUnread}
+          notificationHeading="Notifications"
+          notificationState={`${unreadCount} unread`}
+          notifications="Your export is ready"
+          onOpenChange={(nextOpen) => {
+            setOpen(nextOpen);
+
+            if (!nextOpen) {
+              setUnreadCount(0);
+            }
+          }}
+          open={open}
+          unreadLabel={`Notifications (${unreadCount} unread)`}
+          userName="Morgan Green"
+        />
+      );
+    }
+
+    renderBreeze(<ControlledNotifications />);
+
+    expect(screen.getByText('3 unread')).toBeVisible();
+    await user.keyboard('{Escape}');
+    await waitFor(() =>
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument(),
+    );
+    const trigger = screen.getByRole('button', {
+      name: 'Notifications (0 unread)',
+    });
+
+    await user.click(trigger);
+    expect(screen.getByText('0 unread')).toBeVisible();
   });
 });

--- a/packages/breeze-ui/src/patterns/UserMenu/UserMenu.tsx
+++ b/packages/breeze-ui/src/patterns/UserMenu/UserMenu.tsx
@@ -1,6 +1,7 @@
 import type { ReactElement, ReactNode } from 'react';
+import { useRef } from 'react';
 import { Avatar } from '../../primitives/Avatar/Avatar';
-import { Menu } from '../../primitives/Menu/Menu';
+import { Menu, NonModalMenuPopover } from '../../primitives/Menu/Menu';
 import { useBreezeContext } from '../../provider/BreezeContext';
 
 /** One application-owned user-menu action or destination. */
@@ -21,8 +22,7 @@ export interface UserMenuAction {
   variant?: 'default' | 'danger';
 }
 
-/** Props for account identity, notifications, and application-owned user actions. */
-export interface UserMenuProps {
+interface UserMenuSharedProps {
   /** Accessible name for the menu trigger. */
   'aria-label': string;
   /** Ordered application-owned actions. */
@@ -37,9 +37,31 @@ export interface UserMenuProps {
   notificationState?: ReactNode;
   /** Optional avatar image URL. */
   src?: string;
+  /** Complete accessible trigger name used when unread content is present. */
+  unreadLabel?: string;
   /** Visible represented user name. */
   userName: string;
 }
+
+interface ControlledUserMenuProps {
+  defaultOpen?: never;
+  /** Called with the next menu state. */
+  onOpenChange: (open: boolean) => void;
+  /** Current menu state. */
+  open: boolean;
+}
+
+interface UncontrolledUserMenuProps {
+  /** Initial menu state. Defaults to `false`. */
+  defaultOpen?: boolean;
+  /** Called with the next menu state. */
+  onOpenChange?: (open: boolean) => void;
+  open?: never;
+}
+
+/** Props for account identity, notifications, and application-owned user actions. */
+export type UserMenuProps = UserMenuSharedProps &
+  (ControlledUserMenuProps | UncontrolledUserMenuProps);
 
 /**
  * Presents user identity, notification content, and keyboard-complete account
@@ -50,25 +72,30 @@ export interface UserMenuProps {
 export function UserMenu({
   'aria-label': ariaLabel,
   actions,
+  defaultOpen,
   hasUnread = false,
   notificationHeading,
   notificationState,
   notifications,
+  onOpenChange,
+  open,
   src,
+  unreadLabel,
   userName,
 }: Readonly<UserMenuProps>): ReactElement {
   const { messages } = useBreezeContext();
-
-  return (
-    <Menu.Root>
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const menuContent = (
+    <>
       <Menu.Trigger
         aria-label={
           hasUnread
-            ? `${ariaLabel}, ${messages.unreadNotifications}`
+            ? unreadLabel ?? `${ariaLabel}, ${messages.unreadNotifications}`
             : ariaLabel
         }
         className="relative min-h-14 w-full justify-start gap-3 border-0 bg-transparent p-2 text-start text-inherit data-[hovered]:bg-[var(--breeze-shell-soft)]"
         data-breeze-user-menu-trigger=""
+        ref={triggerRef}
       >
         <span className="relative">
           <Avatar name={userName} size="md" src={src} />
@@ -83,7 +110,11 @@ export function UserMenu({
           {userName}
         </strong>
       </Menu.Trigger>
-      <Menu.Popover className="w-80" nonModal placement="top start">
+      <NonModalMenuPopover
+        className="w-80"
+        placement="top start"
+        triggerRef={triggerRef}
+      >
         {notifications === undefined ? null : (
           <div className="border-b border-[var(--breeze-border)]">
             {notificationHeading === undefined ? null : (
@@ -125,7 +156,21 @@ export function UserMenu({
             </Menu.Item>
           ))}
         </Menu.List>
-      </Menu.Popover>
+      </NonModalMenuPopover>
+    </>
+  );
+
+  if (open === undefined) {
+    return (
+      <Menu.Root defaultOpen={defaultOpen} onOpenChange={onOpenChange}>
+        {menuContent}
+      </Menu.Root>
+    );
+  }
+
+  return (
+    <Menu.Root onOpenChange={onOpenChange} open={open}>
+      {menuContent}
     </Menu.Root>
   );
 }

--- a/packages/breeze-ui/src/patterns/pattern-props.types.test.tsx
+++ b/packages/breeze-ui/src/patterns/pattern-props.types.test.tsx
@@ -1,7 +1,20 @@
 import { describe, expectTypeOf, it } from 'vitest';
+import type { ApplicationShellProps } from './ApplicationShell/ApplicationShell';
 import type { ConfirmationDialogProps } from './ConfirmationDialog/ConfirmationDialog';
 import type { PasswordFieldProps } from './PasswordField/PasswordField';
 import type { SegmentedControlProps } from './SegmentedControl/SegmentedControl';
+import type { UserMenuProps } from './UserMenu/UserMenu';
+
+// @ts-expect-error controlled compact navigation requires a change callback
+const invalidApplicationShell: ApplicationShellProps = {
+  account: 'Account',
+  brand: 'Product',
+  children: 'Content',
+  compactNavigationOpen: true,
+  navigation: 'Navigation',
+  navigationLabel: 'Open navigation',
+  skipLinkLabel: 'Skip to content',
+};
 
 // @ts-expect-error controlled confirmation state requires a callback unless read-only
 const invalidConfirmation: ConfirmationDialogProps = {
@@ -36,15 +49,26 @@ const missingConfirmationTrigger: ConfirmationDialogProps = {
   onConfirm: () => undefined,
   title: 'Title',
 };
+// @ts-expect-error controlled user-menu state requires a change callback
+const invalidUserMenu: UserMenuProps = {
+  actions: [],
+  'aria-label': 'User menu',
+  open: true,
+  userName: 'Taylor Reed',
+};
 
 describe('pattern public prop contracts', () => {
   it('seals underlying implementation props', () => {
+    expectTypeOf(
+      invalidApplicationShell,
+    ).toMatchTypeOf<ApplicationShellProps>();
     expectTypeOf(invalidConfirmation).toMatchTypeOf<ConfirmationDialogProps>();
     expectTypeOf(
       missingConfirmationTrigger,
     ).toMatchTypeOf<ConfirmationDialogProps>();
     expectTypeOf(invalidPassword).toMatchTypeOf<PasswordFieldProps>();
     expectTypeOf(invalidSegmented).toMatchTypeOf<SegmentedControlProps>();
+    expectTypeOf(invalidUserMenu).toMatchTypeOf<UserMenuProps>();
     expectTypeOf<PasswordFieldProps>().not.toHaveProperty('isDisabled');
     expectTypeOf<PasswordFieldProps>().not.toHaveProperty('onPress');
     expectTypeOf<SegmentedControlProps>().not.toHaveProperty('selectedKeys');

--- a/packages/breeze-ui/src/primitives/Menu/Menu.tsx
+++ b/packages/breeze-ui/src/primitives/Menu/Menu.tsx
@@ -4,14 +4,16 @@ import type {
   ReactElement,
   ReactNode,
   Ref,
+  RefObject,
 } from 'react';
-import { createElement } from 'react';
+import { createElement, useContext } from 'react';
 import { Button as AriaButton } from 'react-aria-components/Button';
 import {
   Menu as AriaMenu,
   MenuItem as AriaMenuItem,
   MenuTrigger as AriaMenuTrigger,
   Popover as AriaPopover,
+  RootMenuTriggerStateContext as AriaRootMenuTriggerStateContext,
   SubmenuTrigger as AriaSubmenuTrigger,
 } from 'react-aria-components/Menu';
 import { tv } from 'tailwind-variants';
@@ -221,10 +223,13 @@ export function Trigger({
   ref,
   ...props
 }: Readonly<MenuTriggerProps>): ReactElement {
+  const triggerState = useContext(AriaRootMenuTriggerStateContext);
+
   return createElement(AriaButton, {
     ...props,
     className: menuTrigger({ class: className }),
     isDisabled: disabled,
+    onPress: triggerState?.isOpen ? triggerState.close : undefined,
     ref: useForwardedRef(ref),
   } as ComponentProps<typeof AriaButton>);
 }
@@ -245,6 +250,36 @@ export function Popover({
     isNonModal: nonModal,
     placement,
     ref: useForwardedRef(ref),
+  } as ComponentProps<typeof AriaPopover>);
+}
+
+interface NonModalMenuPopoverProps extends Omit<MenuPopoverProps, 'nonModal'> {
+  triggerRef: RefObject<Element | null>;
+}
+
+/**
+ * Positions a non-modal menu without treating its own trigger as an outside
+ * dismissal target.
+ *
+ * @internal
+ */
+export function NonModalMenuPopover({
+  className,
+  placement = 'bottom start',
+  ref,
+  triggerRef,
+  ...props
+}: Readonly<NonModalMenuPopoverProps>): ReactElement {
+  useBreezeContext();
+
+  return createElement(AriaPopover, {
+    ...props,
+    className: menuPopover({ class: className }),
+    isNonModal: true,
+    placement,
+    ref: useForwardedRef(ref),
+    shouldCloseOnInteractOutside: (element: Element) =>
+      triggerRef.current?.contains(element) !== true,
   } as ComponentProps<typeof AriaPopover>);
 }
 


### PR DESCRIPTION
## Summary

- add controlled and uncontrolled compact-navigation lifecycle props to `ApplicationShell`
- close compact navigation after ordinary in-app navigation while preserving modified clicks, new-tab links, history, focus, Escape, scroll-lock, and wide-rail behavior
- add controlled and uncontrolled state to `UserMenu`, with exact-once dismissal callbacks and complete count-aware accessible labels
- document the public contracts and cover them with type tests, interaction tests, and responsive stories

## Validation

- `yarn workspace @motech-development/breeze-ui test` — 106 files, 345 tests passed
- `yarn workspace @motech-development/breeze-ui typecheck`
- `yarn workspace @motech-development/breeze-ui lint`
- `yarn workspace @motech-development/breeze-ui formatting`
- `yarn workspace @motech-development/breeze-ui build`
- affected Storybook tests — 7 tests passed in Chromium

Closes #1541


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added controlled open/close behavior for ApplicationShell compact navigation and UserMenu.
  * Navigation can now close automatically after standard route changes.
  * Added localized unread notification labels with accurate counts.
  * Improved menu dismissal behavior for Escape, outside clicks, trigger clicks, and menu actions.
* **Documentation**
  * Expanded guidance and examples for controlled and uncontrolled usage, accessibility, localization, and supported state combinations.
* **Tests**
  * Added coverage for navigation, dismissal, unread labels, and controlled state behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->