### PR TITLE
feat(breeze-ui): focus shell content after navigation

### DIFF
--- a/packages/breeze-ui/src/patterns/ApplicationShell/ApplicationShell.mdx
+++ b/packages/breeze-ui/src/patterns/ApplicationShell/ApplicationShell.mdx
@@ -94,6 +94,7 @@ useEffect(() => {
 
 <ApplicationShell
   compactNavigationOpen={compactNavigationOpen}
+  contentFocusKey={route}
   onCompactNavigationOpenChange={setCompactNavigationOpen}
   // ...
 />;
@@ -108,6 +109,7 @@ Keep destinations as links and close from an observed route change. Do not repla
 - Use a labelled `NavigationList.Root` and set `current` from the active route. Local links use the `BreezeProvider` router adapter when configured; native anchors handle external URLs and native link behaviours.
 - The drawer trigger and close action use normal button keyboard activation. Focus, `Escape` dismissal, focus containment, scroll locking, and restoration are supplied by `Drawer`.
 - The main target has `tabIndex={-1}` so the skip link can move focus to it. Keep the first page heading inside `children`.
+- Pass the current application route as `contentFocusKey` to move focus to the main target after routed content changes. The focus is deferred until closing overlays have completed their own focus restoration.
 
 `ApplicationShell` has no disabled, read-only, invalid, loading, empty, or error mode. Render page feedback inside `children`, disable the relevant slotted controls themselves, and keep navigation and account recovery available whenever possible.
 

--- a/packages/breeze-ui/src/patterns/ApplicationShell/ApplicationShell.test.tsx
+++ b/packages/breeze-ui/src/patterns/ApplicationShell/ApplicationShell.test.tsx
@@ -1,4 +1,4 @@
-import { screen, within } from '@testing-library/react';
+import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useState } from 'react';
 import { describe, expect, it, vi } from 'vitest';
@@ -54,6 +54,7 @@ describe('ApplicationShell', () => {
 
     function ControlledShell() {
       const [compactNavigationOpen, setCompactNavigationOpen] = useState(true);
+      const [contentFocusKey, setContentFocusKey] = useState('/overview');
 
       return (
         <BreezeProvider
@@ -62,6 +63,7 @@ describe('ApplicationShell', () => {
             navigate: (href) => {
               navigate(href);
               setCompactNavigationOpen(false);
+              setContentFocusKey(href);
             },
           }}
         >
@@ -69,6 +71,7 @@ describe('ApplicationShell', () => {
             account={<span>Account</span>}
             brand={<strong>Product</strong>}
             compactNavigationOpen={compactNavigationOpen}
+            contentFocusKey={contentFocusKey}
             navigation={
               <nav aria-label="Primary navigation">
                 <Link href="/projects">Projects</Link>
@@ -90,6 +93,7 @@ describe('ApplicationShell', () => {
     renderBreeze(<ControlledShell />);
 
     const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveFocus();
     const destination = within(dialog).getByRole('link', { name: 'Projects' });
     const newTabDestination = within(dialog).getByRole('link', {
       name: 'Open projects in a new tab',
@@ -113,5 +117,6 @@ describe('ApplicationShell', () => {
     await user.click(destination);
     expect(navigate).toHaveBeenCalledExactlyOnceWith('/projects');
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    await waitFor(() => expect(screen.getByRole('main')).toHaveFocus());
   });
 });

--- a/packages/breeze-ui/src/patterns/ApplicationShell/ApplicationShell.tsx
+++ b/packages/breeze-ui/src/patterns/ApplicationShell/ApplicationShell.tsx
@@ -1,5 +1,5 @@
-import type { HTMLAttributes, ReactElement, ReactNode, Ref } from 'react';
-import { createElement } from 'react';
+import type { HTMLAttributes, Key, ReactElement, ReactNode, Ref } from 'react';
+import { createElement, useEffect, useRef } from 'react';
 import { CloseIcon, MenuIcon } from '../../icons';
 import useForwardedRef from '../../internal/hooks/useForwardedRef';
 import { Drawer } from '../../primitives/Drawer/Drawer';
@@ -16,6 +16,8 @@ interface ApplicationShellSharedProps
   children: ReactNode;
   /** Compact-header product name. Defaults to `brand`. */
   compactBrand?: ReactNode;
+  /** Focuses the main-content target after this application-owned content key changes. */
+  contentFocusKey?: Key;
   /** Optional active application-context slot. */
   context?: ReactNode;
   /** Accessible title for the compact navigation drawer. */
@@ -64,6 +66,7 @@ export function ApplicationShell({
   compactBrand,
   compactNavigationOpen,
   context,
+  contentFocusKey,
   defaultCompactNavigationOpen,
   mainId = 'main-content',
   navigation,
@@ -74,6 +77,25 @@ export function ApplicationShell({
   ...props
 }: Readonly<ApplicationShellProps>): ReactElement {
   const { messages } = useBreezeContext();
+  const mainRef = useRef<HTMLElement>(null);
+  const previousContentFocusKey = useRef(contentFocusKey);
+
+  useEffect(() => {
+    const previousKey = previousContentFocusKey.current;
+
+    previousContentFocusKey.current = contentFocusKey;
+
+    if (contentFocusKey === undefined || contentFocusKey === previousKey) {
+      return undefined;
+    }
+
+    const frame = window.requestAnimationFrame(() => {
+      mainRef.current?.focus();
+    });
+
+    return () => window.cancelAnimationFrame(frame);
+  }, [contentFocusKey]);
+
   const compactNavigationContent = (
     <>
       <Drawer.Trigger
@@ -164,6 +186,7 @@ export function ApplicationShell({
       <main
         className="min-h-dvh px-4 py-6 sm:px-8 sm:py-12 md:ms-64 lg:px-12"
         id={mainId}
+        ref={mainRef}
         tabIndex={-1}
       >
         {children}


### PR DESCRIPTION
## What changed

- add an opt-in `contentFocusKey` to Breeze `ApplicationShell`
- focus the shell-owned main-content target after the key changes
- defer focus until the next animation frame so closing overlays complete focus restoration first
- document the routing contract and cover the drawer-to-route focus lifecycle

## Why

React Aria correctly restores focus when an overlay closes. When that close happens alongside client-side navigation, the restoration can race with the application's route focus and leave the new page content unfocused. `ApplicationShell` already owns the main landmark, skip-link target, and focusability, so it is the right layer to provide the reusable behaviour while the application supplies only its route key.

The capability is opt-in and does not change ordinary `Drawer` focus restoration or focus anything on initial shell mount.

## Impact

Applications can pass their current route as `contentFocusKey` to get consistent focus placement after routed content changes without querying the DOM or reimplementing overlay timing.

## Validation

- Breeze unit suite: 106 files, 349 tests passed
- targeted `ApplicationShell` tests passed
- Breeze lint passed
- Breeze type-check passed
- Breeze formatting passed
- Breeze package build passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional focus management for compact navigation, returning keyboard focus to the main content after routed content changes.
  * Documented how to configure content focus behavior for improved accessibility.

* **Bug Fixes**
  * Improved focus restoration after dialogs or overlays close and navigation completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->